### PR TITLE
Relax level naming restriction

### DIFF
--- a/scenes/level_select/level_select.gd
+++ b/scenes/level_select/level_select.gd
@@ -6,7 +6,7 @@ class_name LevelSelect
 @export var button_spacing := Vector2(24, 24)
 
 var current_index := 0
-var level_numbers := []
+var level_files := []
 
 @onready var player_marker := $PlayerMarker
 @onready var button_container := $ButtonGrid
@@ -26,27 +26,27 @@ func load_levels():
 		dir.list_dir_begin()
 		var file_name = dir.get_next()
 		while file_name != "":
+			# levels have filenames matching "level.*\.tscn"
 			if file_name.begins_with("level") && file_name.ends_with(".tscn"):
-				var level_num = file_name.trim_prefix("level").trim_suffix(".tscn")
-				if level_num.is_valid_int():
-					level_numbers.append(level_num.to_int())
-			file_name = dir.get_next()
-		level_numbers.sort()
+				level_files.append(file_name)
+				file_name = dir.get_next()
+
+				# Alphabetical sorting
+				level_files.sort()
 
 
 func create_level_grid():
-	# Clear existing buttons
 	for child in button_container.get_children():
 		child.queue_free()
-	
+
 	var button_scene = preload("res://scenes/level_button/level_button.tscn")
-	
-	for i in level_numbers.size():
+
+	for i in level_files.size():
 		var button = button_scene.instantiate() as LevelButton
 		button.name = "Level%d" % (i + 1)
 		button.level_number = i + 1
 		button.custom_minimum_size = button_size
-		
+
 		# Position calculation
 		var col = i % grid_columns
 		var row = i / grid_columns
@@ -71,13 +71,14 @@ func _input(event):
 	elif event.is_action_pressed("ui_down"):
 		try_move(0, 1)
 	elif event.is_action_pressed("ui_a"):
-		_on_level_selected(current_index + 1)
+		_on_level_selected(current_index)
 
 func try_move(x: int, y: int):
 	var new_index = current_index + x + (y * grid_columns)
-	if new_index >= 0 && new_index < level_numbers.size():
+	if new_index >= 0 && new_index < level_files.size():
 		current_index = new_index
 		update_marker_position()
 
-func _on_level_selected(level_number: int):
-	get_tree().change_scene_to_file("res://levels/level%d.tscn" % level_number)
+func _on_level_selected(level_index: int):
+	var file_path = "res://levels/%s" % level_files[level_index]
+	get_tree().change_scene_to_file(file_path)


### PR DESCRIPTION
- levels used to have filenames maching `level[0-9]+\.tscn`
- levels now have filenames matching `level.*\.tscn`
- levels are sorted alphabetically

- the idea is to avoid merge conflicts when we're both making new levels