### PR TITLE
use _setup_camera_limits instead of adjusting level position/staticcam

### DIFF
--- a/scenes/level_base/level_base.gd
+++ b/scenes/level_base/level_base.gd
@@ -13,21 +13,8 @@ extends Node2D
 
 func _ready():
 	_update_level_bounds()
-
-	# Center the level within the viewport
-	if !Engine.is_editor_hint():
-		var tilemap = $Terrain
-		var tile_size = tilemap.tile_set.tile_size
-
-		var map_width_px = width_in_tiles * tile_size.x
-		var map_height_px = height_in_tiles * tile_size.y
-		var viewport_size = get_viewport().get_visible_rect().size
-
-		# Shift this LevelBase node so that the level is centered
-		position = Vector2(
-			(viewport_size.x - map_width_px) / 2,
-			(viewport_size.y - map_height_px) / 2
-		)
+	if $Player:
+		$Player._setup_camera_limits(width_in_tiles * 8, height_in_tiles * 8)
 
 func _update_level_bounds():
 	if !Engine.is_editor_hint():

--- a/scenes/player/player.gd
+++ b/scenes/player/player.gd
@@ -104,10 +104,11 @@ func return_to_world_select():
 	get_tree().change_scene_to_file("res://scenes/level_select/level_select.tscn")
 
 func _setup_camera_limits(map_width_px, map_height_px):
-	$Camera.limit_left = 0
-	$Camera.limit_right = map_width_px
 	var viewport_width = ProjectSettings.get_setting("display/window/size/viewport_width")
 	var viewport_height = ProjectSettings.get_setting("display/window/size/viewport_height")
+
+	$Camera.limit_left = 0
+	$Camera.limit_right = map_width_px
 	if map_width_px < viewport_width:
 		$Camera.limit_left = map_width_px / 2  - (viewport_width / 2)
 		$Camera.limit_right = map_width_px / 2  + (viewport_width / 2)

--- a/scenes/player/player.gd
+++ b/scenes/player/player.gd
@@ -20,32 +20,16 @@ func _on_player_died():
 	readyForRestart = true
 
 func _ready():
+	add_to_group("player")
 	var camera = $Camera
 	camera.zoom = camera_scale
 	$AudioStreamPlayer2D.playing = play_background_music
 	player_died.connect(_on_player_died)
-	add_to_group("player")
-	var level = get_parent() as Node2D
-	var map_height_px = level.height_in_tiles * tilemaplayer.tile_size.y
-	var map_width_px = level.width_in_tiles * tilemaplayer.tile_size.x
 
 	var fuel_label = get_tree().get_first_node_in_group("fuel_label")
 	if fuel_label:
 		fuel_label.player = self
 
-	if staticCam:
-		# Remove the player and reparent to level.
-		camera.get_parent().remove_child(camera)
-		call_deferred("add_camera_to_level", level, camera)
-		# Set position in the center of the level.
-		camera.global_position = Vector2(map_width_px, map_height_px) / 2
-		camera.enabled = true
-		camera.make_current()
-		
-# Seperate function bc if we don't wait a frame the call will fail. 
-func add_camera_to_level(level: Node2D, camera: Camera2D):
-	level.add_child(camera)
-	
 func add_fuel(amt):
 	FUEL += amt
 	$AudioStreamPlayer2D.pitch_scale = 1.03 # Changesmusic to normal if you ran out of fuel then got it back. 
@@ -118,18 +102,18 @@ func _update_animation(dir: Vector2):
 
 func return_to_world_select():
 	get_tree().change_scene_to_file("res://scenes/level_select/level_select.tscn")
-	
-# Revisit this if we need to set camera limits. Causes more problems than it's worth at the moment. 
-#func _setup_camera_limits():
-	#var level = get_parent() as Node2D
-	#var tilemap = level.get_node("Terrain")
-	#var tile_size = tilemap.tile_set.tile_size
-#
-	#var map_width_px = level.width_in_tiles * tile_size.x
-	#var map_height_px = level.height_in_tiles * tile_size.y
-	#var level_offset = level.global_position
-#
-	#$Camera2D.limit_left = int(level_offset.x)
-	#$Camera2D.limit_top = int(level_offset.y)
-	#$Camera2D.limit_right = int(level_offset.x + map_width_px)
-	#$Camera2D.limit_bottom = int(level_offset.y + map_height_px)
+
+func _setup_camera_limits(map_width_px, map_height_px):
+	$Camera.limit_left = 0
+	$Camera.limit_right = map_width_px
+	var viewport_width = ProjectSettings.get_setting("display/window/size/viewport_width")
+	var viewport_height = ProjectSettings.get_setting("display/window/size/viewport_height")
+	if map_width_px < viewport_width:
+		$Camera.limit_left = map_width_px / 2  - (viewport_width / 2)
+		$Camera.limit_right = map_width_px / 2  + (viewport_width / 2)
+
+	$Camera.limit_top = 0;
+	$Camera.limit_bottom = map_height_px
+	if map_height_px < 360:
+		$Camera.limit_top = map_height_px / 2  - (viewport_height / 2)
+		$Camera.limit_bottom = map_height_px / 2  + (viewport_height / 2)

--- a/scenes/player/player.gd
+++ b/scenes/player/player.gd
@@ -116,9 +116,11 @@ func _setup_camera_limits(map_width_px, map_height_px):
 	if map_width_px < viewport_width:
 		$Camera.limit_left = map_width_px / 2  - (viewport_width / 2)
 		$Camera.limit_right = map_width_px / 2  + (viewport_width / 2)
+		$Camera.drag_horizontal_enabled = false
 
 	# if the level is shorter than the screen, center the level vertically in the camera's view
 	var viewport_height = ProjectSettings.get_setting("display/window/size/viewport_height")
 	if map_height_px < 360:
 		$Camera.limit_top = map_height_px / 2  - (viewport_height / 2)
 		$Camera.limit_bottom = map_height_px / 2  + (viewport_height / 2)
+		$Camera.drag_vertical_enabled = false

--- a/scenes/player/player.gd
+++ b/scenes/player/player.gd
@@ -104,17 +104,21 @@ func return_to_world_select():
 	get_tree().change_scene_to_file("res://scenes/level_select/level_select.tscn")
 
 func _setup_camera_limits(map_width_px, map_height_px):
-	var viewport_width = ProjectSettings.get_setting("display/window/size/viewport_width")
-	var viewport_height = ProjectSettings.get_setting("display/window/size/viewport_height")
-
+	# by default, restrict the camera to the bounding box of the level
 	$Camera.limit_left = 0
 	$Camera.limit_right = map_width_px
+
+	$Camera.limit_top = 0;
+	$Camera.limit_bottom = map_height_px
+
+	# if the level is less wide than the screen, center the level horizontally in the camera's view
+	var viewport_width = ProjectSettings.get_setting("display/window/size/viewport_width")
 	if map_width_px < viewport_width:
 		$Camera.limit_left = map_width_px / 2  - (viewport_width / 2)
 		$Camera.limit_right = map_width_px / 2  + (viewport_width / 2)
 
-	$Camera.limit_top = 0;
-	$Camera.limit_bottom = map_height_px
+	# if the level is shorter than the screen, center the level vertically in the camera's view
+	var viewport_height = ProjectSettings.get_setting("display/window/size/viewport_height")
 	if map_height_px < 360:
 		$Camera.limit_top = map_height_px / 2  - (viewport_height / 2)
 		$Camera.limit_bottom = map_height_px / 2  + (viewport_height / 2)

--- a/scenes/player/player.tscn
+++ b/scenes/player/player.tscn
@@ -94,6 +94,11 @@ position = Vector2(20, 20)
 shape = SubResource("RectangleShape2D_onrkg")
 
 [node name="Camera" type="Camera2D" parent="."]
+limit_left = -100000
+limit_top = -100000
+limit_right = 100000
+limit_bottom = 100000
+limit_smoothed = true
 drag_horizontal_enabled = true
 drag_vertical_enabled = true
 editor_draw_limits = true

--- a/scenes/player/player.tscn
+++ b/scenes/player/player.tscn
@@ -94,13 +94,10 @@ position = Vector2(20, 20)
 shape = SubResource("RectangleShape2D_onrkg")
 
 [node name="Camera" type="Camera2D" parent="."]
-limit_left = -100000
-limit_top = -100000
-limit_right = 100000
-limit_bottom = 100000
-limit_smoothed = true
 drag_horizontal_enabled = true
 drag_vertical_enabled = true
+drag_left_margin = 1.0
+drag_right_margin = 1.0
 editor_draw_limits = true
 editor_draw_drag_margin = true
 

--- a/scenes/player/player.tscn
+++ b/scenes/player/player.tscn
@@ -96,8 +96,6 @@ shape = SubResource("RectangleShape2D_onrkg")
 [node name="Camera" type="Camera2D" parent="."]
 drag_horizontal_enabled = true
 drag_vertical_enabled = true
-drag_left_margin = 1.0
-drag_right_margin = 1.0
 editor_draw_limits = true
 editor_draw_drag_margin = true
 


### PR DESCRIPTION
I think this is a cleaner way of centering levels + establishing camera boundaries
- the camera stays always parented to the player
- levels smaller than the screen size are automatically visually centered
- if the level is larger than the screen size, the camera never goes outside of the level bounds