### PR TITLE
Use standardized units for Physics calculations

### DIFF
--- a/scripts/player.gd
+++ b/scripts/player.gd
@@ -13,15 +13,16 @@ extends CharacterBody2D
 # friction is a ratio and doesn't need to be scaled
 const FRICTION = -3
 
-var GRAVITY = 120
-var PLAYER_Y_FORCE = 300
-var PLAYER_X_FORCE = 165
-var VELOCITY_CUTOFF = 0.001
+var gravity = 120
+var player_y_force = 300
+var player_x_force = 165
+var velocity_cutoff = 0.001
 
 # physics are designed for an 8px x 8px tileset -- 8px == 1m
-const PHYSICS_BASE_SCALE = 8
-const TILE_SIZE_PX = 24
-const PHYSICS_SCALE_FACTOR = TILE_SIZE_PX / PHYSICS_BASE_SCALE
+const BASE_TILE_SIZE_PX = 8
+# @export var tile_size_px = 24
+@export var tile_size_px = 8
+var physics_scale_factor = tile_size_px / BASE_TILE_SIZE_PX
 
 var readyForRestart: bool = false
 
@@ -42,10 +43,10 @@ func _ready():
 	var tilemap = get_parent().get_node("Terrain") as TileMapLayer
 
 	# initialize scaled physics forces
-	GRAVITY *= PHYSICS_SCALE_FACTOR
-	PLAYER_Y_FORCE *= PHYSICS_SCALE_FACTOR
-	PLAYER_X_FORCE *= PHYSICS_SCALE_FACTOR
-	VELOCITY_CUTOFF *= PHYSICS_SCALE_FACTOR
+	gravity *= physics_scale_factor
+	player_y_force *= physics_scale_factor
+	player_x_force *= physics_scale_factor
+	velocity_cutoff *= physics_scale_factor
 
 func add_fuel(amt):
 	FUEL += amt
@@ -67,20 +68,20 @@ func _on_timer_timeout():
 func _physics_process(delta):
 	var input_dir = Input.get_vector("ui_left", "ui_right", "ui_up", "ui_down")
 	var velocity_update = input_dir
-	velocity_update.x *= PLAYER_X_FORCE * delta
-	velocity_update.y *= PLAYER_Y_FORCE * delta
+	velocity_update.x *= player_x_force * delta
+	velocity_update.y *= player_y_force * delta
 
 	if FUEL > 0:
 		velocity -= velocity_update
 		# fuel is independent of scale
-		FUEL -= velocity_update.length() / PHYSICS_SCALE_FACTOR
+		FUEL -= velocity_update.length() / physics_scale_factor
 	elif readyForRestart == false and timer.is_stopped():
 		$AudioStreamPlayer2D.pitch_scale = 0.7
 		timer.start()
 
 	if not is_on_floor():
-		velocity.y += GRAVITY * delta
-	elif abs(velocity.x) < VELOCITY_CUTOFF:
+		velocity.y += gravity * delta
+	elif abs(velocity.x) < velocity_cutoff:
 		velocity.x = 0
 	else:
 		# Makes you slow down when you land on the floor. Smaller than vel.x so slows you down. 

--- a/scripts/player.gd
+++ b/scripts/player.gd
@@ -39,8 +39,6 @@ func _ready():
 	if fuel_label:
 		fuel_label.player = self
 
-	var tilemap = get_parent().get_node("Terrain") as TileMapLayer
-
 func add_fuel(amt):
 	FUEL += amt
 	$AudioStreamPlayer2D.pitch_scale = 1.03 # Changesmusic to normal if you ran out of fuel then got it back. 

--- a/scripts/player.gd
+++ b/scripts/player.gd
@@ -9,15 +9,19 @@ extends CharacterBody2D
 @onready var timer: Timer = $Timer
 @onready var camera = $Camera
 
-# All physics constants are in units of Tiles/Second
+# All forces are in units of Tiles per Second squared
+# friction is a ratio and doesn't need to be scaled
+const FRICTION = -3
+
+var GRAVITY = 120
+var PLAYER_Y_FORCE = 300
+var PLAYER_X_FORCE = 165
+var VELOCITY_CUTOFF = 0.001
+
 # physics are designed for an 8px x 8px tileset -- 8px == 1m
 const PHYSICS_BASE_SCALE = 8
 const TILE_SIZE_PX = 24
 const PHYSICS_SCALE_FACTOR = TILE_SIZE_PX / PHYSICS_BASE_SCALE
-var GRAVITY
-var FRICTION
-var PLAYER_Y_FORCE
-var PLAYER_X_FORCE
 
 var readyForRestart: bool = false
 
@@ -37,11 +41,11 @@ func _ready():
 
 	var tilemap = get_parent().get_node("Terrain") as TileMapLayer
 
-	# init scaled physics constants
-	GRAVITY = 120 * PHYSICS_SCALE_FACTOR
-	FRICTION = -3 * PHYSICS_SCALE_FACTOR
-	PLAYER_Y_FORCE = 300 * PHYSICS_SCALE_FACTOR
-	PLAYER_X_FORCE = 165 * PHYSICS_SCALE_FACTOR
+	# initialize scaled physics forces
+	GRAVITY *= PHYSICS_SCALE_FACTOR
+	PLAYER_Y_FORCE *= PHYSICS_SCALE_FACTOR
+	PLAYER_X_FORCE *= PHYSICS_SCALE_FACTOR
+	VELOCITY_CUTOFF *= PHYSICS_SCALE_FACTOR
 
 func add_fuel(amt):
 	FUEL += amt
@@ -74,12 +78,13 @@ func _physics_process(delta):
 		$AudioStreamPlayer2D.pitch_scale = 0.7
 		timer.start()
 
+
 	if not is_on_floor():
 		velocity.y += GRAVITY * delta
-	elif abs(velocity.x) < 0.001:
+	elif abs(velocity.x) < VELOCITY_CUTOFF:
 		velocity.x = 0
 	else:
-		# Makes you slow down when you land on the floor. Smaller than vel.x so slows you down.
+		# Makes you slow down when you land on the floor. Smaller than vel.x so slows you down. 
 		velocity.x += FRICTION * delta * velocity.x
 
 	move_and_slide()

--- a/scripts/player.gd
+++ b/scripts/player.gd
@@ -13,15 +13,14 @@ extends CharacterBody2D
 # friction is a ratio and doesn't need to be scaled
 const FRICTION = -3
 
-var gravity = 120
-var player_y_force = 300
-var player_x_force = 165
-var velocity_cutoff = 0.001
+var gravity = 120 * physics_scale_factor
+var player_y_force = 300 * physics_scale_factor
+var player_x_force = 165 * physics_scale_factor
+var velocity_cutoff = 0.001 * physics_scale_factor
 
 # physics are designed for an 8px x 8px tileset -- 8px == 1m
 const BASE_TILE_SIZE_PX = 8
-# @export var tile_size_px = 24
-@export var tile_size_px = 8
+@export var tile_size_px = 24
 var physics_scale_factor = tile_size_px / BASE_TILE_SIZE_PX
 
 var readyForRestart: bool = false
@@ -41,12 +40,6 @@ func _ready():
 		fuel_label.player = self
 
 	var tilemap = get_parent().get_node("Terrain") as TileMapLayer
-
-	# initialize scaled physics forces
-	gravity *= physics_scale_factor
-	player_y_force *= physics_scale_factor
-	player_x_force *= physics_scale_factor
-	velocity_cutoff *= physics_scale_factor
 
 func add_fuel(amt):
 	FUEL += amt

--- a/scripts/player.gd
+++ b/scripts/player.gd
@@ -9,6 +9,11 @@ extends CharacterBody2D
 @onready var timer: Timer = $Timer
 @onready var camera = $Camera
 
+# physics are designed for an 8px x 8px tileset -- 8px == 1m
+const BASE_TILE_SIZE_PX = 8
+@export var tile_size_px = 8
+var physics_scale_factor = tile_size_px / BASE_TILE_SIZE_PX
+
 # All forces are in units of Tiles per Second squared
 # friction is a ratio and doesn't need to be scaled
 const FRICTION = -3
@@ -17,11 +22,6 @@ var gravity = 120 * physics_scale_factor
 var player_y_force = 300 * physics_scale_factor
 var player_x_force = 165 * physics_scale_factor
 var velocity_cutoff = 0.001 * physics_scale_factor
-
-# physics are designed for an 8px x 8px tileset -- 8px == 1m
-const BASE_TILE_SIZE_PX = 8
-@export var tile_size_px = 24
-var physics_scale_factor = tile_size_px / BASE_TILE_SIZE_PX
 
 var readyForRestart: bool = false
 

--- a/scripts/player.gd
+++ b/scripts/player.gd
@@ -78,7 +78,6 @@ func _physics_process(delta):
 		$AudioStreamPlayer2D.pitch_scale = 0.7
 		timer.start()
 
-
 	if not is_on_floor():
 		velocity.y += GRAVITY * delta
 	elif abs(velocity.x) < VELOCITY_CUTOFF:


### PR DESCRIPTION
- Scale physics units to size-agnostic units of Tiles/second
- adds the `tile_size_px` exported property to the player
  - this defaults to 8px.
  - if we create a 24px tile sheet, we should increase `tile_size_px` to `24px`
- we could get the tile size from the terrain tilemap, but i think leaving them decoupled is better because it's less code and we shouldn't have to change the tile sheet more than once