### PR TITLE
Implemented player score

### DIFF
--- a/levels/1-11_guantlet.tscn
+++ b/levels/1-11_guantlet.tscn
@@ -42,15 +42,15 @@ position = Vector2(1836, 1040)
 position = Vector2(384, 736)
 size = Vector2(240, 600)
 
-[node name="Slime" parent="." index="14" instance=ExtResource("4_0alfw")]
+[node name="Slime" parent="." index="13" instance=ExtResource("4_0alfw")]
 position = Vector2(1622, 264)
 
-[node name="Slime2" parent="." index="15" instance=ExtResource("4_0alfw")]
+[node name="Slime2" parent="." index="14" instance=ExtResource("4_0alfw")]
 position = Vector2(607, 264)
 
-[node name="Spike" parent="." index="16" instance=ExtResource("5_84md7")]
-position = Vector2(129, 1032)
+[node name="Spike" parent="." index="15" instance=ExtResource("5_84md7")]
+position = Vector2(104, 1008)
 
-[node name="Spike2" parent="." index="17" instance=ExtResource("5_84md7")]
-position = Vector2(129, 312)
+[node name="Spike2" parent="." index="16" instance=ExtResource("5_84md7")]
+position = Vector2(152, 336)
 rotation = 3.14159

--- a/scenes/UI/hud.tscn
+++ b/scenes/UI/hud.tscn
@@ -22,9 +22,9 @@ layout_mode = 1
 anchors_preset = 1
 anchor_left = 1.0
 anchor_right = 1.0
-offset_left = 1400.0
-offset_right = 1610.0
-offset_bottom = 48.0
+offset_left = -210.0
+offset_top = 60.0
+offset_bottom = 108.0
 grow_horizontal = 0
 theme_override_styles/normal = ExtResource("2_18exe")
 text = "Fuel: 1000"
@@ -41,16 +41,11 @@ theme_override_styles/normal = ExtResource("2_18exe")
 label_settings = ExtResource("3_0jeyp")
 vertical_alignment = 1
 
-[node name="Level_Complete" type="Label" parent="Control"]
+[node name="Score" type="Label" parent="Control"]
 unique_name_in_owner = true
-visible = false
 layout_mode = 0
-offset_left = 310.0
-offset_top = 400.0
-offset_right = 1087.0
-offset_bottom = 442.0
+offset_left = 1350.0
+offset_right = 1390.0
+offset_bottom = 42.0
 theme_override_styles/normal = ExtResource("2_18exe")
-text = "Level Complete! Loading Next Level..."
 label_settings = ExtResource("3_0jeyp")
-horizontal_alignment = 1
-vertical_alignment = 1

--- a/scenes/game_manager.tscn
+++ b/scenes/game_manager.tscn
@@ -22,7 +22,7 @@ bus = &"Music"
 
 [node name="CanvasLayer" type="CanvasLayer" parent="."]
 
-[node name="Player_Died" type="Label" parent="CanvasLayer"]
+[node name="GameInfo" type="Label" parent="CanvasLayer"]
 unique_name_in_owner = true
 visible = false
 anchors_preset = 8

--- a/scripts/UI/hud.gd
+++ b/scripts/UI/hud.gd
@@ -8,8 +8,5 @@ func _process(_delta: float) -> void:
 	
 	var fuel_amount = max(0, int(player.FUEL))
 	%Fuel.text = "Fuel: %d" % fuel_amount
-	%Lives.text = "Lives: %d" % GameManager.lives	
-	if GameManager.levelComplete:
-		%Level_Complete.visible = true
-	else:
-		%Level_Complete.visible = false
+	%Lives.text = "Lives: %d" % GameManager.lives
+	%Score.text = "Score: %d" % GameManager.score

--- a/scripts/end_zone.gd
+++ b/scripts/end_zone.gd
@@ -12,7 +12,7 @@ func _ready():
 	update_shape()
 
 func _on_body_entered(body):
-	if body.is_in_group("player"):
+	if body.is_in_group("player") and not GameManager.endZoneTriggered:
 		GameManager.load_next_level()
 
 func _process(_delta):

--- a/scripts/game_manager.gd
+++ b/scripts/game_manager.gd
@@ -4,10 +4,10 @@
 extends Control
 var curr_level = 0
 var lives = 1
-# TODO: Implement score feature and give extra lives for enough score.
+# 10k score gives an extra life. You automatically get 1k per level, plus however much fuel you have left over. 
 var score = 0
+var extraLivesDivisor = 1
 var level_files = []
-var levelComplete = false
 var endZoneTriggered = false
 # Show a message upon levelCompletion
 @onready var background_music = $Background_Music
@@ -30,43 +30,63 @@ func load_levels():
 func reset():
 	lives = 3
 	score = 0
+	extraLivesDivisor = 1
 	curr_level = 0
 	background_music.pitch_scale = 1.03
 	
 func load_next_level():
-	levelComplete = true
 	if curr_level > 0:
-		var player = get_player()
-		# Prevents bug where level resets if enetering endzone when out of fuel. 
+		background_music.pitch_scale = 1.03
+		# Prevents bug where level resets if entering endzone when out of fuel. 
 		endZoneTriggered = true
 		# Freeze to prevent player death after endzone trigger
-		player.set_physics_process(false)
-		await get_tree().create_timer(2).timeout
-		player.set_physics_process(true)
-		endZoneTriggered = false
+		await calculateScore() 
+		await get_tree().create_timer(1).timeout
 	var level_path = "res://levels/%s" % level_files[curr_level]
 	curr_level += 1
-	levelComplete = false
 	get_tree().change_scene_to_file(level_path)
+	# Must go after changing scene to avoid issues.
+	endZoneTriggered = false
 	
-	
+func calculateScore():
+	%GameInfo.text = "Level Complete! +1000 Score!"
+	%GameInfo.visible = true
+	await get_tree().create_timer(1).timeout
+	score += 1000 # for level clear
+	%GameInfo.visible = false
+	await scoreCountDown()
+	if score > 10000 * extraLivesDivisor:
+		lives += 1
+		extraLivesDivisor += 1
+		
+func scoreCountDown():
+	var player = get_player()
+	while player.FUEL > 0:
+		if player.FUEL <= 5:
+			player.FUEL -= 1
+			score += 1
+		else:
+			player.FUEL -= 5
+			score += 5
+		await get_tree().process_frame
+		
 func on_player_died():
 	if endZoneTriggered:
 		background_music.pitch_scale = 1.03
 		return
 	lives -= 1
 	if lives > 0:
-		%Player_Died.text = "YOU DIED! RESETTING LEVEL..."
-		%Player_Died.visible = true
+		%Game_Info.text = "YOU DIED! RESETTING LEVEL..."
+		%Game_Info.visible = true
 		await get_tree().create_timer(2).timeout
 		background_music.pitch_scale = 1.03
-		%Player_Died.visible = false
+		%Game_Died.visible = false
 		get_tree().reload_current_scene()
 	else:
-		%Player_Died.text = "GAME OVER! BACK TO LEVEL 1 :) "
-		%Player_Died.visible = true
+		%Game_Info.text = "GAME OVER! BACK TO LEVEL 1 :) "
+		%Game_Info.visible = true
 		await get_tree().create_timer(2).timeout
-		%Player_Died.visible = false
+		%Game_Info.visible = false
 		reset()
 		load_next_level()
 

--- a/scripts/player.gd
+++ b/scripts/player.gd
@@ -40,7 +40,7 @@ func add_fuel(amt):
 	GameManager.background_music.pitch_scale = 1.03 # Changes music to normal if you ran out of fuel then got it back. 
 
 func _on_timer_timeout():
-	if int(FUEL) <= 0:
+	if int(FUEL) <= 0 && not GameManager.endZoneTriggered:
 		emit_signal("player_died")
 
 func _get_friction():
@@ -68,8 +68,9 @@ func _physics_process(delta):
 	if FUEL > 0:
 		velocity -= velocity_update
 		# fuel is independent of scale
-		FUEL -= velocity_update.length() / physics_scale_factor
-	elif timer.is_stopped():
+		if not GameManager.endZoneTriggered:
+			FUEL -= velocity_update.length() / physics_scale_factor
+	elif timer.is_stopped() and not GameManager.endZoneTriggered:
 		GameManager.background_music.pitch_scale = 0.7
 		timer.start()
 


### PR DESCRIPTION
- 10k points = extra life
- Implemented Fuel count-down/score count-up
- You can move freely at the end of the level with no fuel penalty. 
    - GameManager.endZoneTriggered is used to disable fuel use and a couple other things in this case
    - You can still collect fuel cans to add to your score in this case. Could be removed, but I like it as a high-end skill 
    potential for high scores
- Fixed spike positioning for level 11
- Lives and fuel on top left of UI, score (and probably time later) on the right side
      - This is what spelunky does and prob a lot of other games. 