### PR TITLE
End of level fixes

### DIFF
--- a/scenes/UI/hud.tscn
+++ b/scenes/UI/hud.tscn
@@ -22,20 +22,19 @@ layout_mode = 1
 anchors_preset = 1
 anchor_left = 1.0
 anchor_right = 1.0
-offset_left = -210.0
+offset_left = -147.0
 offset_top = 60.0
 offset_bottom = 108.0
 grow_horizontal = 0
 theme_override_styles/normal = ExtResource("2_18exe")
-text = "Fuel: 1000"
+text = "Fuel: 0"
 label_settings = ExtResource("3_0jeyp")
 vertical_alignment = 1
 
 [node name="Lives" type="Label" parent="Control"]
 unique_name_in_owner = true
 layout_mode = 1
-offset_left = -210.0
-offset_right = -40.0
+offset_left = -170.0
 offset_bottom = 48.0
 theme_override_styles/normal = ExtResource("2_18exe")
 label_settings = ExtResource("3_0jeyp")

--- a/scripts/game_manager.gd
+++ b/scripts/game_manager.gd
@@ -55,9 +55,13 @@ func calculateScore():
 	score += 1000 # for level clear
 	%GameInfo.visible = false
 	await scoreCountDown()
-	if score > 10000 * extraLivesDivisor:
+
+	var extra_life_frame_delay = 45
+	while score > 10000 * extraLivesDivisor:
 		lives += 1
 		extraLivesDivisor += 1
+		for i in range(extra_life_frame_delay):
+			await get_tree().process_frame
 		
 func scoreCountDown():
 	var player = get_player()

--- a/scripts/game_manager.gd
+++ b/scripts/game_manager.gd
@@ -65,6 +65,9 @@ func scoreCountDown():
 		if player.FUEL <= 5:
 			player.FUEL -= 1
 			score += 1
+		elif player.FUEL >= 2000:
+			player.FUEL -= 100
+			score += 100
 		else:
 			player.FUEL -= 5
 			score += 5

--- a/scripts/game_manager.gd
+++ b/scripts/game_manager.gd
@@ -7,6 +7,7 @@ var lives = 1
 # 10k score gives an extra life. You automatically get 1k per level, plus however much fuel you have left over. 
 var score = 0
 var extraLivesDivisor = 1
+var extraLifeFrameDelay = .5 # value in seconds. time between life increases when receiving multiple lives
 var level_files = []
 var endZoneTriggered = false
 # Show a message upon levelCompletion
@@ -57,7 +58,7 @@ func calculateScore():
 	await scoreCountDown()
 
 	while score > 10000 * extraLivesDivisor:
-		await get_tree().create_timer(.5).timeout
+		await get_tree().create_timer(extraLifeFrameDelay).timeout
 		lives += 1
 		extraLivesDivisor += 1
 		

--- a/scripts/game_manager.gd
+++ b/scripts/game_manager.gd
@@ -56,12 +56,10 @@ func calculateScore():
 	%GameInfo.visible = false
 	await scoreCountDown()
 
-	var extra_life_frame_delay = 45
 	while score > 10000 * extraLivesDivisor:
+		await get_tree().create_timer(.5).timeout
 		lives += 1
 		extraLivesDivisor += 1
-		for i in range(extra_life_frame_delay):
-			await get_tree().process_frame
 		
 func scoreCountDown():
 	var player = get_player()

--- a/scripts/killzone.gd
+++ b/scripts/killzone.gd
@@ -3,7 +3,8 @@ extends Area2D
 @onready var timer: Timer = $Timer
 
 func _on_body_entered(_body: Node2D) -> void:
-	timer.start()
+	if not GameManager.endZoneTriggered:
+		timer.start()
 
 func _on_timer_timeout() -> void:
 	get_tree().reload_current_scene()


### PR DESCRIPTION
# Fixes
- `killzone.gd`
  - disable killzone after player has triggered the end zone
- `game_manager.gd`
  - count down fuel 20x faster while player fuel > 2000
  - count up extra lives at the end of the level
- `hud.tscn`
  - make right edge of fuel label and lives label aligned at all points

# Demo
[Screencast from 2025-04-17 11-30-57.webm](https://github.com/user-attachments/assets/d27aff95-50d6-4102-b261-a6659d2c2300)
