### PR TITLE
saving high score and time trial cleanup

### DIFF
--- a/scenes/main.tscn
+++ b/scenes/main.tscn
@@ -47,6 +47,33 @@ text = "SMOKIN MY LASER"
 label_settings = ExtResource("4_eb6dy")
 horizontal_alignment = 1
 
+[node name="HighScore" type="Panel" parent="."]
+anchors_preset = -1
+anchor_left = 0.224299
+anchor_top = 0.1
+anchor_right = 0.224299
+anchor_bottom = 0.1
+offset_left = 560.0
+offset_top = 32.0
+offset_right = 1360.0
+offset_bottom = 92.0
+theme_override_styles/panel = ExtResource("2_ya4ey")
+
+[node name="Score" type="Label" parent="HighScore"]
+unique_name_in_owner = true
+layout_mode = 1
+anchors_preset = 5
+anchor_left = 0.5
+anchor_right = 0.5
+offset_left = -352.0
+offset_top = 8.0
+offset_right = 352.0
+offset_bottom = 50.0
+grow_horizontal = 2
+text = "High Score:"
+label_settings = ExtResource("4_eb6dy")
+horizontal_alignment = 1
+
 [node name="PlayerTexture" type="TextureRect" parent="."]
 z_index = -1
 anchors_preset = 1

--- a/scripts/game_manager.gd
+++ b/scripts/game_manager.gd
@@ -84,21 +84,35 @@ func save_time_and_return():
 	var prev_time = GameManager.level_data.level_times.get(level_path, null)
 	# If this is the first level clear
 	if prev_time == null or str(time) == "":
+		%GameInfo.text = "New Best Time: "+ str(round(time * 1000) / 1000.0)
+		%GameInfo.visible = true
 		level_data.level_times[level_path] = round(time * 1000) / 1000.0
 		save_data()
 	else:
 		var previous_best_time = level_data.level_times[level_path]
 		if time < previous_best_time:
-			save_data()
+			%GameInfo.text = "New Best Time: "+ str(round(time * 1000) / 1000.0)
+			%GameInfo.visible = true
 			level_data.level_times[level_path] = round(time * 1000) / 1000.0
+			save_data()
+	await get_tree().create_timer(1).timeout
+	%GameInfo.visible = false
 	get_tree().change_scene_to_file("res://scenes/UI/level_select.tscn")
 	gameStateDisabled = false
 	
 func _input(event):
+	if gameMode == GameModes.TIME_TRIAL:
+		if event.is_action_pressed("reset"):
+			game_started = false
+			reset()
+			get_tree().reload_current_scene()
 	# Start the timer upon the first input
-	if event.is_action_type():
-		game_started = true
+		elif event.is_pressed():
+			game_started = true
 	 # DEV: Go to next level
+	elif gameMode == GameModes.ARCADE:
+		if event.is_pressed():
+			game_started = true
 	if event.is_action_pressed("ui_n"):
 		if curr_level == len(level_files):
 			curr_level = 0
@@ -163,7 +177,12 @@ func on_player_died():
 				background_music.pitch_scale = 1.03
 				get_tree().reload_current_scene()
 			else:
-				%GameInfo.text = "GAME OVER! BACK TO LEVEL 1 :) "
+				if GameManager.level_data.high_score < score:
+					%GameInfo.text = "New High Score!"
+					level_data.high_score = score
+					save_data()
+				else:
+					%GameInfo.text = "GAME OVER! BACK TO LEVEL 1 :) "
 				%GameInfo.visible = true
 				await get_tree().create_timer(1.5).timeout
 				reset()

--- a/scripts/game_manager.gd
+++ b/scripts/game_manager.gd
@@ -178,7 +178,7 @@ func on_player_died():
 				get_tree().reload_current_scene()
 			else:
 				if GameManager.level_data.high_score < score:
-					%GameInfo.text = "New High Score!"
+					%GameInfo.text = "New High Score! " + str(score)
 					level_data.high_score = score
 					save_data()
 				else:

--- a/scripts/level_data.gd
+++ b/scripts/level_data.gd
@@ -4,3 +4,5 @@ class_name LevelData
 
 # Gets populated upon time trial level clear
 @export var level_times = {}
+
+@export var high_score = 0

--- a/scripts/main.gd
+++ b/scripts/main.gd
@@ -4,6 +4,7 @@ extends Node
 func _ready():
 	GameManager.reset()
 	%ArcadeButton.grab_focus()
+	%Score.text = "High Score: " + str(GameManager.level_data.high_score) 
 
 func _on_arcade_button_pressed() -> void:
 	GameManager.load_next_level()


### PR DESCRIPTION
- Now saving arcade mode high score
    - Will need to add saving upon game completion once celebration level is implemented
- Fixed time trial bug where new high score wouldn't save after closing the app.
- Allow for r = reset level in time trial mode 
- Added "New Best Time" text when setting a new best time in time trial mode. 
- "New High Score" text upon setting high score in arcade mode