### PR TITLE
Map controller `Back` button to reset signal

### DIFF
--- a/project.godot
+++ b/project.godot
@@ -69,6 +69,7 @@ ui_q={
 reset={
 "deadzone": 0.2,
 "events": [null, Object(InputEventKey,"resource_local_to_scene":false,"resource_name":"","device":-1,"window_id":0,"alt_pressed":false,"shift_pressed":false,"ctrl_pressed":false,"meta_pressed":false,"pressed":false,"keycode":0,"physical_keycode":82,"key_label":0,"unicode":114,"location":0,"echo":false,"script":null)
+, Object(InputEventJoypadButton,"resource_local_to_scene":false,"resource_name":"","device":-1,"button_index":4,"pressure":0.0,"pressed":true,"script":null)
 ]
 }
 ui_n={

--- a/scripts/UI/hud.gd
+++ b/scripts/UI/hud.gd
@@ -19,11 +19,4 @@ func _process(delta: float) -> void:
 	if GameManager.gameMode == GameManager.GameModes.ARCADE:
 		%Lives.text = "Lives: %d" % GameManager.lives
 		%Score.text = "Score: %d" % GameManager.score
-	%Timer.text = _format_seconds(GameManager.time)
-
-func _format_seconds(time : float) -> String:
-	var minutes := time / 60
-	var seconds := fmod(time, 60)
-	var milliseconds := fmod(time, 1) * 100
-
-	return "%02d:%02d:%02d" % [minutes, seconds, milliseconds]
+	%Timer.text = GameManager.format_seconds(GameManager.time)

--- a/scripts/UI/level_select.gd
+++ b/scripts/UI/level_select.gd
@@ -77,4 +77,4 @@ func _update_level_info_display(level_index):
 	if time == null or str(time) == "":
 		%LevelStats.text = "Level Not Complete"
 	else:
-		%LevelStats.text = str(time)
+		%LevelStats.text = GameManager.format_seconds(time)

--- a/scripts/game_manager.gd
+++ b/scripts/game_manager.gd
@@ -84,14 +84,14 @@ func save_time_and_return():
 	var prev_time = GameManager.level_data.level_times.get(level_path, null)
 	# If this is the first level clear
 	if prev_time == null or str(time) == "":
-		%GameInfo.text = "New Best Time: "+ str(round(time * 1000) / 1000.0)
+		%GameInfo.text = "New Best Time: "+ format_seconds(time)
 		%GameInfo.visible = true
 		level_data.level_times[level_path] = round(time * 1000) / 1000.0
 		save_data()
 	else:
 		var previous_best_time = level_data.level_times[level_path]
 		if time < previous_best_time:
-			%GameInfo.text = "New Best Time: "+ str(round(time * 1000) / 1000.0)
+			%GameInfo.text = "New Best Time: "+ format_seconds(time)
 			%GameInfo.visible = true
 			level_data.level_times[level_path] = round(time * 1000) / 1000.0
 			save_data()
@@ -197,3 +197,10 @@ func on_player_died():
 func get_player(): 
 	var level = get_tree().get_current_scene()
 	return level.get_node("Player")
+
+func format_seconds(time : float) -> String:
+	var minutes := time / 60
+	var seconds := fmod(time, 60)
+	var milliseconds := fmod(time, 1) * 100
+
+	return "%02d:%02d:%02d" % [minutes, seconds, milliseconds]


### PR DESCRIPTION
- Map controller Back button to reset signal
  - This allows controller users to reset time trials levels
 - Update all times to be displayed in 00:00:00 format