### PR TITLE
Feature/arcade time save

### DIFF
--- a/levels/1-03_slide.tscn
+++ b/levels/1-03_slide.tscn
@@ -9,6 +9,7 @@
 [ext_resource type="PackedScene" uid="uid://cxdl0fqxwxba1" path="res://scenes/gas_can.tscn" id="7_kbwtv"]
 
 [node name="LevelBase" instance=ExtResource("1_fcjjs")]
+level_name = "Slide"
 width_in_tiles = 200
 height_in_tiles = 32
 

--- a/levels/1-04_tunnel.tscn
+++ b/levels/1-04_tunnel.tscn
@@ -7,6 +7,7 @@
 [ext_resource type="PackedScene" uid="uid://bvn2y2nnqcrts" path="res://scenes/end_zone.tscn" id="3_dbmku"]
 
 [node name="LevelBase" instance=ExtResource("1_dl2t3")]
+level_name = "Tunnel"
 width_in_tiles = 250
 height_in_tiles = 20
 

--- a/scenes/main.tscn
+++ b/scenes/main.tscn
@@ -109,7 +109,7 @@ offset_left = 276.0
 offset_top = 288.0
 offset_right = 1095.0
 offset_bottom = 348.0
-focus_neighbor_top = NodePath("../QuitToDesktopButton")
+focus_neighbor_top = NodePath("../ClearSaveButton")
 focus_neighbor_bottom = NodePath("../TrialButton")
 theme = ExtResource("4_o6xl0")
 theme_override_colors/font_hover_color = Color(1, 1, 1, 1)
@@ -225,7 +225,7 @@ offset_top = 431.0
 offset_right = 1095.0
 offset_bottom = 491.0
 focus_neighbor_top = NodePath("../TrialButton")
-focus_neighbor_bottom = NodePath("../ArcadeButton")
+focus_neighbor_bottom = NodePath("../ClearSaveButton")
 theme = ExtResource("4_o6xl0")
 theme_override_colors/font_hover_color = Color(1, 1, 1, 1)
 theme_override_colors/font_color = Color(0, 0, 0, 1)
@@ -234,6 +234,32 @@ theme_override_styles/focus = ExtResource("2_tefeu")
 theme_override_styles/hover = ExtResource("4_choun")
 theme_override_styles/normal = ExtResource("4_choun")
 text = "Quit To Desktop"
+
+[node name="ClearSaveButton" type="Button" parent="."]
+offset_left = 276.0
+offset_top = 504.0
+offset_right = 1095.0
+offset_bottom = 564.0
+focus_neighbor_top = NodePath("../QuitToDesktopButton")
+focus_neighbor_bottom = NodePath("../ArcadeButton")
+theme = ExtResource("4_o6xl0")
+theme_override_colors/font_hover_color = Color(1, 1, 1, 1)
+theme_override_colors/font_color = Color(0, 0, 0, 1)
+theme_override_font_sizes/font_size = 33
+theme_override_styles/focus = ExtResource("2_tefeu")
+theme_override_styles/hover = ExtResource("4_choun")
+theme_override_styles/normal = ExtResource("4_choun")
+text = "Clear Save Data"
+
+[node name="ConfirmationDialog" type="ConfirmationDialog" parent="ClearSaveButton"]
+unique_name_in_owner = true
+ok_button_text = "Yes"
+dialog_text = "Are you  sure you want to delete your save data?"
+cancel_button_text = "No"
+
+[node name="SaveClearedDialog" type="AcceptDialog" parent="ClearSaveButton"]
+unique_name_in_owner = true
+dialog_text = "Save data cleared."
 
 [node name="Backdrop" type="Node2D" parent="."]
 z_index = -1
@@ -288,3 +314,5 @@ metadata/_edit_use_anchors_ = true
 [connection signal="pressed" from="ArcadeButton" to="." method="_on_arcade_button_pressed"]
 [connection signal="pressed" from="TrialButton" to="." method="_on_trial_button_pressed"]
 [connection signal="pressed" from="QuitToDesktopButton" to="." method="_on_quit_to_desktop_button_pressed"]
+[connection signal="pressed" from="ClearSaveButton" to="." method="_on_clear_save_button_pressed"]
+[connection signal="confirmed" from="ClearSaveButton/ConfirmationDialog" to="." method="_on_confirmation_dialog_confirmed"]

--- a/scenes/main.tscn
+++ b/scenes/main.tscn
@@ -124,14 +124,14 @@ text = "Arcade Mode"
 [node name="HighScore" type="HBoxContainer" parent="ArcadeButton"]
 clip_contents = true
 layout_mode = 0
-offset_left = 831.0
-offset_right = 1010.0
+offset_left = 828.0
+offset_right = 978.0
 offset_bottom = 20.0
-scale = Vector2(3, 3)
+scale = Vector2(2.5, 2.5)
 theme_override_constants/separation = 0
 
 [node name="placeholder1" type="Label" parent="ArcadeButton/HighScore"]
-custom_minimum_size = Vector2(15, 20)
+custom_minimum_size = Vector2(5, 20)
 layout_mode = 2
 theme_override_styles/normal = ExtResource("4_choun")
 label_settings = ExtResource("13_trceg")
@@ -146,7 +146,7 @@ label_settings = ExtResource("13_trceg")
 vertical_alignment = 1
 
 [node name="placeholder2" type="Label" parent="ArcadeButton/HighScore"]
-custom_minimum_size = Vector2(36, 20)
+custom_minimum_size = Vector2(5, 20)
 layout_mode = 2
 theme_override_styles/normal = ExtResource("4_choun")
 label_settings = ExtResource("13_trceg")
@@ -159,6 +159,47 @@ layout_mode = 2
 size_flags_horizontal = 3
 theme_override_styles/normal = ExtResource("4_choun")
 text = "10942"
+label_settings = ExtResource("13_trceg")
+vertical_alignment = 1
+
+[node name="BestTime" type="HBoxContainer" parent="ArcadeButton"]
+clip_contents = true
+layout_mode = 0
+offset_left = 1228.0
+offset_right = 1374.0
+offset_bottom = 20.0
+scale = Vector2(2.5, 2.5)
+theme_override_constants/separation = 0
+
+[node name="placeholder1" type="Label" parent="ArcadeButton/BestTime"]
+custom_minimum_size = Vector2(5, 20)
+layout_mode = 2
+theme_override_styles/normal = ExtResource("4_choun")
+label_settings = ExtResource("13_trceg")
+horizontal_alignment = 1
+
+[node name="HighScoreLabel" type="Label" parent="ArcadeButton/BestTime"]
+custom_minimum_size = Vector2(77, 20)
+layout_mode = 2
+theme_override_styles/normal = ExtResource("4_choun")
+text = "Best Time:"
+label_settings = ExtResource("13_trceg")
+vertical_alignment = 1
+
+[node name="placeholder2" type="Label" parent="ArcadeButton/BestTime"]
+custom_minimum_size = Vector2(5, 20)
+layout_mode = 2
+theme_override_styles/normal = ExtResource("4_choun")
+label_settings = ExtResource("13_trceg")
+horizontal_alignment = 1
+
+[node name="Time" type="Label" parent="ArcadeButton/BestTime"]
+unique_name_in_owner = true
+custom_minimum_size = Vector2(0, 20)
+layout_mode = 2
+size_flags_horizontal = 3
+theme_override_styles/normal = ExtResource("4_choun")
+text = "00:00:00"
 label_settings = ExtResource("13_trceg")
 vertical_alignment = 1
 

--- a/scripts/level_data.gd
+++ b/scripts/level_data.gd
@@ -6,3 +6,6 @@ class_name LevelData
 @export var level_times = {}
 
 @export var high_score = 0
+
+# Null until best time is set
+@export var arcade_time = null

--- a/scripts/main.gd
+++ b/scripts/main.gd
@@ -3,9 +3,15 @@ extends Node
 var focused = false;
 
 func _ready():
+	GameManager.time = 0.0
 	GameManager.reset()
+	GameManager.gameMode = GameManager.GameModes.NONE
 	%ArcadeButton.grab_focus()
 	%Score.text = str(GameManager.level_data.high_score)
+	if not GameManager.level_data.arcade_time == null:
+		%Time.text = GameManager.format_seconds(GameManager.level_data.arcade_time)
+
+		
 
 func _on_arcade_button_pressed() -> void:
 	GameManager.load_first_level()
@@ -21,19 +27,33 @@ func _on_quit_to_desktop_button_pressed() -> void:
 func _on_arcade_button_focus_entered() -> void:
 	focused = true
 	_set_high_score_visibility(true)
+	_set_best_time_visibility(true)
 
 func _on_arcade_button_focus_exited() -> void:
 	focused = false
 	_set_high_score_visibility(false)
+	_set_best_time_visibility(false)
 
 func _on_arcade_button_mouse_entered() -> void:
 	_set_high_score_visibility(true)
+	_set_best_time_visibility(true)
 
 func _on_arcade_button_mouse_exited() -> void:
 	_set_high_score_visibility(false)
+	_set_best_time_visibility(false)
 
 func _set_high_score_visibility(val):
 	if focused:
 		$ArcadeButton/HighScore.visible = true
 	else:
 		$ArcadeButton/HighScore.visible = val
+
+func _set_best_time_visibility(val):
+	if not GameManager.level_data.arcade_time == null:
+		if focused:
+			$ArcadeButton/BestTime.visible = true
+		else:
+			$ArcadeButton/BestTime.visible = val
+	else:
+		$ArcadeButton/BestTime.visible = false
+			

--- a/scripts/main.gd
+++ b/scripts/main.gd
@@ -11,8 +11,6 @@ func _ready():
 	if not GameManager.level_data.arcade_time == null:
 		%Time.text = GameManager.format_seconds(GameManager.level_data.arcade_time)
 
-		
-
 func _on_arcade_button_pressed() -> void:
 	GameManager.load_first_level()
 	GameManager.gameMode = GameManager.GameModes.ARCADE
@@ -60,11 +58,8 @@ func _set_best_time_visibility(val):
 	else:
 		$ArcadeButton/BestTime.visible = false
 			
-
-
 func _on_clear_save_button_pressed() -> void:
 	%ConfirmationDialog.popup_centered()
-
 
 func _on_confirmation_dialog_confirmed() -> void:
 	var save_path = "user://level_data.tres"
@@ -86,4 +81,3 @@ func _on_confirmation_dialog_confirmed() -> void:
 		%SaveClearedDialog.dialog_text = "No save data found."
 	
 	%SaveClearedDialog.popup_centered()
-		

--- a/scripts/main.gd
+++ b/scripts/main.gd
@@ -43,10 +43,13 @@ func _on_arcade_button_mouse_exited() -> void:
 	_set_best_time_visibility(false)
 
 func _set_high_score_visibility(val):
-	if focused:
-		$ArcadeButton/HighScore.visible = true
+	if not GameManager.level_data.high_score == 0:
+		if focused:
+			$ArcadeButton/HighScore.visible = true
+		else:
+			$ArcadeButton/HighScore.visible = val
 	else:
-		$ArcadeButton/HighScore.visible = val
+		$ArcadeButton/HighScore.visible = false
 
 func _set_best_time_visibility(val):
 	if not GameManager.level_data.arcade_time == null:
@@ -57,3 +60,30 @@ func _set_best_time_visibility(val):
 	else:
 		$ArcadeButton/BestTime.visible = false
 			
+
+
+func _on_clear_save_button_pressed() -> void:
+	%ConfirmationDialog.popup_centered()
+
+
+func _on_confirmation_dialog_confirmed() -> void:
+	var save_path = "user://level_data.tres"
+	if FileAccess.file_exists(save_path):
+		var dir = DirAccess.open("user://")
+		if dir:
+			var err = dir.remove("level_data.tres")
+			if err == OK:
+				print("Save data cleared")
+				%SaveClearedDialog.dialog_text = "Save data cleared."
+			else:
+				print("Failed to delete save data.")
+				%SaveClearedDialog.dialog_text = "Failed to delete save data."
+		else:
+			print("Failed to open user directory,")
+			%SaveClearedDialog.dialog_text = "Could not access save directory."
+	else:
+		print("No save data found.")
+		%SaveClearedDialog.dialog_text = "No save data found."
+	
+	%SaveClearedDialog.popup_centered()
+		

--- a/scripts/main.gd
+++ b/scripts/main.gd
@@ -62,22 +62,8 @@ func _on_clear_save_button_pressed() -> void:
 	%ConfirmationDialog.popup_centered()
 
 func _on_confirmation_dialog_confirmed() -> void:
-	var save_path = "user://level_data.tres"
-	if FileAccess.file_exists(save_path):
-		var dir = DirAccess.open("user://")
-		if dir:
-			var err = dir.remove("level_data.tres")
-			if err == OK:
-				print("Save data cleared")
-				%SaveClearedDialog.dialog_text = "Save data cleared."
-			else:
-				print("Failed to delete save data.")
-				%SaveClearedDialog.dialog_text = "Failed to delete save data."
-		else:
-			print("Failed to open user directory,")
-			%SaveClearedDialog.dialog_text = "Could not access save directory."
-	else:
-		print("No save data found.")
-		%SaveClearedDialog.dialog_text = "No save data found."
-	
+	GameManager.level_data.level_times = {}
+	GameManager.level_data.high_score = 0
+	GameManager.level_data.arcade_time = null
+	GameManager.save_data()
 	%SaveClearedDialog.popup_centered()


### PR DESCRIPTION
- Timer now persists through levels in arcade mode
- Saves best time and displays it on the title screen upon completing the game (if it was faster than your previous best)
- High score and best time are not displayed on the title screen until they've been set once
- Added "Clear Save Data" button to title screen with confirmation dialogue. 
- Added names to levels 3 and 4