### PR TITLE
now showing developer best times on level-select time trial interface

### DIFF
--- a/assets/styles/sbf_focus_border.tres
+++ b/assets/styles/sbf_focus_border.tres
@@ -1,0 +1,9 @@
+[gd_resource type="StyleBoxFlat" format=3 uid="uid://6wsnnv0sfrkl"]
+
+[resource]
+bg_color = Color(1, 0, 0.266667, 1)
+border_width_left = 4
+border_width_top = 4
+border_width_right = 4
+border_width_bottom = 4
+border_color = Color(0.996078, 0.682353, 0.203922, 1)

--- a/assets/styles/sbf_gold.tres
+++ b/assets/styles/sbf_gold.tres
@@ -1,0 +1,4 @@
+[gd_resource type="StyleBoxFlat" format=3 uid="uid://cfs8jynviw56p"]
+
+[resource]
+bg_color = Color(0.996078, 0.682353, 0.203922, 1)

--- a/assets/styles/sbf_light_border.tres
+++ b/assets/styles/sbf_light_border.tres
@@ -1,0 +1,9 @@
+[gd_resource type="StyleBoxFlat" format=3 uid="uid://qqpyq85widv0"]
+
+[resource]
+bg_color = Color(0.917647, 0.831373, 0.666667, 1)
+border_width_left = 4
+border_width_top = 4
+border_width_right = 4
+border_width_bottom = 4
+border_color = Color(0.996078, 0.682353, 0.203922, 1)

--- a/scenes/UI/level_button.tscn
+++ b/scenes/UI/level_button.tscn
@@ -1,7 +1,7 @@
 [gd_scene load_steps=4 format=3 uid="uid://etfl8u7dfwws"]
 
 [ext_resource type="Theme" uid="uid://bcn6jcu02pjx0" path="res://assets/themes/standard_font_theme.theme" id="2_fe81u"]
-[ext_resource type="StyleBox" uid="uid://002qwq5rvs87" path="res://assets/styles/sbf_light.tres" id="3_7rldp"]
+[ext_resource type="StyleBox" uid="uid://002qwq5rvs87" path="res://assets/styles/sbf_light.tres" id="4_btco6"]
 [ext_resource type="StyleBox" uid="uid://cn1chxlsybisf" path="res://assets/styles/sbf_focus.tres" id="5_7l7mv"]
 
 [node name="LevelButton" type="Button"]
@@ -11,5 +11,5 @@ offset_bottom = 48.0
 theme = ExtResource("2_fe81u")
 theme_override_colors/font_color = Color(0, 0, 0, 1)
 theme_override_styles/focus = ExtResource("5_7l7mv")
-theme_override_styles/hover = ExtResource("3_7rldp")
-theme_override_styles/normal = ExtResource("3_7rldp")
+theme_override_styles/hover = ExtResource("4_btco6")
+theme_override_styles/normal = ExtResource("4_btco6")

--- a/scenes/UI/level_select.tscn
+++ b/scenes/UI/level_select.tscn
@@ -65,29 +65,20 @@ custom_minimum_size = Vector2(0, 140)
 layout_mode = 2
 columns = 5
 
-[node name="TimeToBeat" type="Label" parent="VBoxContainer"]
-unique_name_in_owner = true
-custom_minimum_size = Vector2(0, 44)
-layout_mode = 2
-theme_override_styles/normal = ExtResource("2_chg43")
-text = "Time To Beat"
-label_settings = ExtResource("2_rif6e")
-horizontal_alignment = 1
-
-[node name="HBoxContainer" type="HBoxContainer" parent="VBoxContainer"]
+[node name="PlayerTime" type="HBoxContainer" parent="VBoxContainer"]
 custom_minimum_size = Vector2(273, 0)
 layout_mode = 2
 size_flags_horizontal = 0
 theme_override_constants/separation = 0
 
-[node name="placeholder2" type="Label" parent="VBoxContainer/HBoxContainer"]
+[node name="placeholder2" type="Label" parent="VBoxContainer/PlayerTime"]
 custom_minimum_size = Vector2(15, 20)
 layout_mode = 2
 theme_override_styles/normal = ExtResource("2_chg43")
 label_settings = ExtResource("3_chg43")
 horizontal_alignment = 1
 
-[node name="LevelNumber" type="Label" parent="VBoxContainer/HBoxContainer"]
+[node name="LevelNumber" type="Label" parent="VBoxContainer/PlayerTime"]
 unique_name_in_owner = true
 custom_minimum_size = Vector2(73, 20)
 layout_mode = 2
@@ -97,14 +88,53 @@ label_settings = ExtResource("3_chg43")
 vertical_alignment = 1
 clip_text = true
 
-[node name="placeholder3" type="Label" parent="VBoxContainer/HBoxContainer"]
+[node name="placeholder3" type="Label" parent="VBoxContainer/PlayerTime"]
 custom_minimum_size = Vector2(40, 20)
 layout_mode = 2
 theme_override_styles/normal = ExtResource("2_chg43")
 label_settings = ExtResource("3_chg43")
 horizontal_alignment = 1
 
-[node name="LevelStats" type="Label" parent="VBoxContainer/HBoxContainer"]
+[node name="LevelStats" type="Label" parent="VBoxContainer/PlayerTime"]
+unique_name_in_owner = true
+custom_minimum_size = Vector2(20, 20)
+layout_mode = 2
+size_flags_horizontal = 3
+theme_override_styles/normal = ExtResource("2_chg43")
+text = "Not Completed"
+label_settings = ExtResource("3_chg43")
+vertical_alignment = 1
+
+[node name="DeveloperTime" type="HBoxContainer" parent="VBoxContainer"]
+custom_minimum_size = Vector2(273, 0)
+layout_mode = 2
+size_flags_horizontal = 0
+theme_override_constants/separation = 0
+
+[node name="placeholder2" type="Label" parent="VBoxContainer/DeveloperTime"]
+custom_minimum_size = Vector2(15, 20)
+layout_mode = 2
+theme_override_styles/normal = ExtResource("2_chg43")
+label_settings = ExtResource("3_chg43")
+horizontal_alignment = 1
+
+[node name="Dev Time" type="Label" parent="VBoxContainer/DeveloperTime"]
+custom_minimum_size = Vector2(73, 20)
+layout_mode = 2
+theme_override_styles/normal = ExtResource("2_chg43")
+text = "Dev Time:"
+label_settings = ExtResource("3_chg43")
+vertical_alignment = 1
+clip_text = true
+
+[node name="placeholder3" type="Label" parent="VBoxContainer/DeveloperTime"]
+custom_minimum_size = Vector2(40, 20)
+layout_mode = 2
+theme_override_styles/normal = ExtResource("2_chg43")
+label_settings = ExtResource("3_chg43")
+horizontal_alignment = 1
+
+[node name="TimeToBeat" type="Label" parent="VBoxContainer/DeveloperTime"]
 unique_name_in_owner = true
 custom_minimum_size = Vector2(20, 20)
 layout_mode = 2

--- a/scenes/UI/level_select.tscn
+++ b/scenes/UI/level_select.tscn
@@ -66,6 +66,7 @@ layout_mode = 2
 columns = 5
 
 [node name="PlayerTime" type="HBoxContainer" parent="VBoxContainer"]
+unique_name_in_owner = true
 custom_minimum_size = Vector2(273, 0)
 layout_mode = 2
 size_flags_horizontal = 0

--- a/scripts/UI/hud.gd
+++ b/scripts/UI/hud.gd
@@ -21,7 +21,7 @@ func _process(_delta) -> void:
 	if GameManager.gameMode == GameManager.GameModes.ARCADE:
 		%Lives.text = "Lives: %d" % GameManager.lives
 		%Score.text = "Score: %d" % GameManager.score
-	%Timer.text = GameManager.format_seconds(GameManager.time)
+	%Timer.text = GameManager.format_milliseconds(GameManager.time)
 	
 func display_level_name():
 	if GameManager.gameMode == GameManager.GameModes.ARCADE:

--- a/scripts/UI/hud.gd
+++ b/scripts/UI/hud.gd
@@ -21,7 +21,7 @@ func _process(_delta) -> void:
 	if GameManager.gameMode == GameManager.GameModes.ARCADE:
 		%Lives.text = "Lives: %d" % GameManager.lives
 		%Score.text = "Score: %d" % GameManager.score
-	%Timer.text = GameManager.format_milliseconds(GameManager.time)
+	%Timer.text = GameManager.format_milliseconds(floori(GameManager.time))
 	
 func display_level_name():
 	if GameManager.gameMode == GameManager.GameModes.ARCADE:

--- a/scripts/UI/level_select.gd
+++ b/scripts/UI/level_select.gd
@@ -79,4 +79,4 @@ func _update_level_info_display(level_index):
 	else:
 		%LevelStats.text = GameManager.format_seconds(time)
 	var dev_time = GameManager.level_data.dev_times[level_index]
-	%TimeToBeat.text = dev_time
+	%TimeToBeat.text = GameManager.format_seconds(dev_time)

--- a/scripts/UI/level_select.gd
+++ b/scripts/UI/level_select.gd
@@ -104,4 +104,4 @@ func _dev_time_beaten(level_index):
 
 	var dev_time = GameManager.level_data.dev_times[level_index]
 
-	return recorded_time < dev_time
+	return recorded_time <= dev_time

--- a/scripts/UI/level_select.gd
+++ b/scripts/UI/level_select.gd
@@ -33,6 +33,11 @@ func _create_level_grid():
 		button.mouse_entered.connect(_update_level_info_display.bind(i))
 		button.mouse_exited.connect(_mouse_exit)
 
+		if _dev_time_beaten(i):
+			button.add_theme_stylebox_override("normal", preload("res://assets/styles/sbf_light_border.tres"))
+			button.add_theme_stylebox_override("hover", preload("res://assets/styles/sbf_light_border.tres"))
+			button.add_theme_stylebox_override("focus", preload("res://assets/styles/sbf_focus_border.tres"))
+
 	# update focus neighbors to allow for horizontal wrapping
 	for i in n_levels:
 		var neighbor_left_idx = (i - 1) % n_levels
@@ -80,3 +85,12 @@ func _update_level_info_display(level_index):
 		%LevelStats.text = GameManager.format_seconds(time)
 	var dev_time = GameManager.level_data.dev_times[level_index]
 	%TimeToBeat.text = GameManager.format_seconds(dev_time)
+
+
+func _dev_time_beaten(level_index):
+	var level_file = level_files[level_index]
+	var level_path = "res://levels/%s" % level_file
+	var time = GameManager.level_data.level_times.get(level_path, 1000)
+	var dev_time = GameManager.level_data.dev_times[level_index]
+
+	return time < dev_time

--- a/scripts/UI/level_select.gd
+++ b/scripts/UI/level_select.gd
@@ -78,3 +78,5 @@ func _update_level_info_display(level_index):
 		%LevelStats.text = "Level Not Complete"
 	else:
 		%LevelStats.text = GameManager.format_seconds(time)
+	var dev_time = GameManager.level_data.dev_times[level_index]
+	%TimeToBeat.text = dev_time

--- a/scripts/UI/level_select.gd
+++ b/scripts/UI/level_select.gd
@@ -36,7 +36,6 @@ func _create_level_grid():
 		if _dev_time_beaten(i):
 			button.add_theme_stylebox_override("normal", preload("res://assets/styles/sbf_light_border.tres"))
 			button.add_theme_stylebox_override("hover", preload("res://assets/styles/sbf_light_border.tres"))
-			button.add_theme_stylebox_override("focus", preload("res://assets/styles/sbf_focus_border.tres"))
 
 	# update focus neighbors to allow for horizontal wrapping
 	for i in n_levels:
@@ -86,6 +85,15 @@ func _update_level_info_display(level_index):
 	var dev_time = GameManager.level_data.dev_times[level_index]
 	%TimeToBeat.text = GameManager.format_seconds(dev_time)
 
+	# set the player time panel gold if the dev time is beaten
+	var sbf_style
+	if _dev_time_beaten(level_index):
+		sbf_style = preload("res://assets/styles/sbf_gold.tres")
+	else:
+		sbf_style = preload("res://assets/styles/sbf_light.tres")
+
+	for l: Label in %PlayerTime.get_children():
+		l.add_theme_stylebox_override("normal", sbf_style)
 
 func _dev_time_beaten(level_index):
 	var level_file = level_files[level_index]

--- a/scripts/UI/level_select.gd
+++ b/scripts/UI/level_select.gd
@@ -81,9 +81,9 @@ func _update_level_info_display(level_index):
 	if time == null or str(time) == "":
 		%LevelStats.text = "Level Not Complete"
 	else:
-		%LevelStats.text = GameManager.format_seconds(time)
+		%LevelStats.text = GameManager.format_milliseconds(time)
 	var dev_time = GameManager.level_data.dev_times[level_index]
-	%TimeToBeat.text = GameManager.format_seconds(dev_time)
+	%TimeToBeat.text = GameManager.format_milliseconds(dev_time)
 
 	# set the player time panel gold if the dev time is beaten
 	var sbf_style
@@ -98,7 +98,10 @@ func _update_level_info_display(level_index):
 func _dev_time_beaten(level_index):
 	var level_file = level_files[level_index]
 	var level_path = "res://levels/%s" % level_file
-	var time = GameManager.level_data.level_times.get(level_path, 1000)
+	var recorded_time = GameManager.level_data.level_times.get(level_path, -1)
+	if recorded_time == -1:
+		return false
+
 	var dev_time = GameManager.level_data.dev_times[level_index]
 
-	return time < dev_time
+	return recorded_time < dev_time

--- a/scripts/game_manager.gd
+++ b/scripts/game_manager.gd
@@ -132,7 +132,7 @@ func save_time_and_return():
 	gameStateDisabled = true
 	var level_path = get_tree().current_scene.scene_file_path
 	await get_tree().create_timer(1).timeout
-	var prev_time: int = GameManager.level_data.level_times.get(level_path, null)
+	var prev_time = GameManager.level_data.level_times.get(level_path, null)
 	var recorded_time: int = floori(time)
 
 	# If this is the first level clear, or if the recorded time has been beaten

--- a/scripts/game_manager.gd
+++ b/scripts/game_manager.gd
@@ -101,11 +101,11 @@ func load_next_level():
 			level_data.high_score = score
 			save_data()
 		if GameManager.level_data.arcade_time == null:
-			await _display_info_duration("New Best Time! " + format_milliseconds(time), 2.5)
+			await _display_info_duration("New Best Time! " + format_milliseconds(floori(time)), 2.5)
 			level_data.arcade_time = time
 			save_data()
 		elif GameManager.level_data.arcade_time > time:
-			await _display_info_duration("New Best Time! " + format_milliseconds(time), 2.5)
+			await _display_info_duration("New Best Time! " + format_milliseconds(floori(time)), 2.5)
 			level_data.arcade_time = time
 			save_data()
 

--- a/scripts/game_manager.gd
+++ b/scripts/game_manager.gd
@@ -235,8 +235,8 @@ func get_player():
 	return level.get_node("Player")
 
 func format_seconds(temp_time : float) -> String:
-	var minutes := temp_time / 60
-	var seconds := fmod(temp_time, 60)
-	var milliseconds := fmod(temp_time, 1) * 100
+	var minutes : int = floori(temp_time / 60)
+	var seconds : int = floori(fmod(temp_time, 60))
+	var milliseconds : float = fmod(temp_time, 1) * 100
 
-	return "%02d:%02d:%02d" % [minutes, seconds, milliseconds]
+	return "%02d:%02d:%02.f" % [minutes, seconds, milliseconds]

--- a/scripts/game_manager.gd
+++ b/scripts/game_manager.gd
@@ -132,18 +132,15 @@ func save_time_and_return():
 	gameStateDisabled = true
 	var level_path = get_tree().current_scene.scene_file_path
 	await get_tree().create_timer(1).timeout
-	var prev_time = GameManager.level_data.level_times.get(level_path, null)
-	# If this is the first level clear
-	if prev_time == null or str(time) == "":
-		await _display_info_duration("New Best Time: "+ format_milliseconds(time), 1)
-		level_data.level_times[level_path] = time
+	var prev_time: int = GameManager.level_data.level_times.get(level_path, null)
+	var recorded_time: int = floori(time)
+
+	# If this is the first level clear, or if the recorded time has been beaten
+	# save the new time
+	if prev_time == null or str(prev_time) == "" or recorded_time < prev_time:
+		await _display_info_duration("New Best Time: "+ format_milliseconds(recorded_time), 1)
+		level_data.level_times[level_path] = recorded_time
 		save_data()
-	else:
-		var previous_best_time = level_data.level_times[level_path]
-		if time < previous_best_time:
-			await _display_info_duration("New Best Time: "+ format_milliseconds(time), 1)
-			level_data.level_times[level_path] = time
-			save_data()
 	get_tree().change_scene_to_file("res://scenes/UI/level_select.tscn")
 	background_music.pitch_scale = 1.03
 	gameStateDisabled = false

--- a/scripts/game_manager.gd
+++ b/scripts/game_manager.gd
@@ -140,9 +140,10 @@ func save_time_and_return():
 		save_data()
 	else:
 		var previous_best_time = level_data.level_times[level_path]
-		if time < previous_best_time:
+		var comparison_time = round(time * 1000) / 1000.0
+		if comparison_time < previous_best_time:
 			await _display_info_duration("New Best Time: "+ format_seconds(time), 1)
-			level_data.level_times[level_path] = round(time * 1000) / 1000.0
+			level_data.level_times[level_path] = comparison_time
 			save_data()
 	get_tree().change_scene_to_file("res://scenes/UI/level_select.tscn")
 	background_music.pitch_scale = 1.03

--- a/scripts/level_data.gd
+++ b/scripts/level_data.gd
@@ -5,6 +5,6 @@ class_name LevelData
 # Gets populated upon time trial level clear
 @export var level_times = {}
 # hard-coded developer best times for time trail levels. 
-const dev_times = [9.68, 9.47, 4.55, 5.06, 23.85, 19.25, 15.22, 17.49, 19.32, 11.16, 28.85, 12.80, 5.05, 17.92, 38.38]
+const dev_times = [9680, 9470, 4550, 5060, 23850, 19250, 600000, 17490, 19320, 600000, 600000, 600000, 600000, 600000, 600000]
 @export var high_score = 0
 @export var arcade_time = null

--- a/scripts/level_data.gd
+++ b/scripts/level_data.gd
@@ -4,8 +4,7 @@ class_name LevelData
 
 # Gets populated upon time trial level clear
 @export var level_times = {}
-
+# hard-coded developer best times for time trail levels. 
+const dev_times = ["00:09:68", "00:09:46", "00:04:65", "00:05:13", "00:25:71", "10:00:00", "10:00:00", "10:00:00", "10:00:00", "10:00:00", "10:00:00", "10:00:00", "10:00:00", "10:00:00", "10:00:00"]
 @export var high_score = 0
-
-# Null until best time is set
 @export var arcade_time = null

--- a/scripts/level_data.gd
+++ b/scripts/level_data.gd
@@ -5,6 +5,6 @@ class_name LevelData
 # Gets populated upon time trial level clear
 @export var level_times = {}
 # hard-coded developer best times for time trail levels. 
-const dev_times = [9.68, 9.46, 4.65, 5.13, 25.71, 600.00, 600.00, 600.00, 600.00, 600.00, 600.00, 600.00, 600.00, 600.00, 600.00]
+const dev_times = [9.68, 9.47, 4.55, 5.06, 23.85, 19.25, 600.00, 600.00, 600.00, 600.00, 600.00, 600.00, 600.00, 600.00, 600.00]
 @export var high_score = 0
 @export var arcade_time = null

--- a/scripts/level_data.gd
+++ b/scripts/level_data.gd
@@ -5,6 +5,6 @@ class_name LevelData
 # Gets populated upon time trial level clear
 @export var level_times = {}
 # hard-coded developer best times for time trail levels. 
-const dev_times = [9.68, 9.47, 4.55, 5.06, 23.85, 19.25, 600.00, 17.49, 19.32, 600.00, 600.00, 600.00, 600.00, 600.00, 600.00]
+const dev_times = [9.68, 9.47, 4.55, 5.06, 23.85, 19.25, 600.00, 17.49, 19.32, 600.00, 28.85, 12.80, 5.05, 17.92, 600.00]
 @export var high_score = 0
 @export var arcade_time = null

--- a/scripts/level_data.gd
+++ b/scripts/level_data.gd
@@ -5,6 +5,6 @@ class_name LevelData
 # Gets populated upon time trial level clear
 @export var level_times = {}
 # hard-coded developer best times for time trail levels. 
-const dev_times = [9680, 9470, 4550, 5060, 23850, 19250, 15220, 17490, 19320, 11160, 28850, 12800, 5050, 17920, 38380]
+const dev_times: Array[int] = [9680, 9470, 4550, 5058, 23850, 19250, 15220, 17490, 19320, 11160, 28850, 12800, 5050, 17920, 38380]
 @export var high_score = 0
 @export var arcade_time = null

--- a/scripts/level_data.gd
+++ b/scripts/level_data.gd
@@ -5,6 +5,6 @@ class_name LevelData
 # Gets populated upon time trial level clear
 @export var level_times = {}
 # hard-coded developer best times for time trail levels. 
-const dev_times = [9680, 9470, 4550, 5060, 23850, 19250, 600000, 17490, 19320, 600000, 600000, 600000, 600000, 600000, 600000]
+const dev_times = [9680, 9470, 4550, 5060, 23850, 19250, 15220, 17490, 19320, 11160, 28850, 12800, 5050, 17920, 38380]
 @export var high_score = 0
 @export var arcade_time = null

--- a/scripts/level_data.gd
+++ b/scripts/level_data.gd
@@ -5,6 +5,6 @@ class_name LevelData
 # Gets populated upon time trial level clear
 @export var level_times = {}
 # hard-coded developer best times for time trail levels. 
-const dev_times = [9.68, 9.47, 4.55, 5.06, 23.85, 19.25, 600.00, 600.00, 600.00, 600.00, 600.00, 600.00, 600.00, 600.00, 600.00]
+const dev_times = [9.68, 9.47, 4.55, 5.06, 23.85, 19.25, 600.00, 17.49, 19.32, 600.00, 600.00, 600.00, 600.00, 600.00, 600.00]
 @export var high_score = 0
 @export var arcade_time = null

--- a/scripts/level_data.gd
+++ b/scripts/level_data.gd
@@ -5,6 +5,6 @@ class_name LevelData
 # Gets populated upon time trial level clear
 @export var level_times = {}
 # hard-coded developer best times for time trail levels. 
-const dev_times = ["00:09:68", "00:09:46", "00:04:65", "00:05:13", "00:25:71", "10:00:00", "10:00:00", "10:00:00", "10:00:00", "10:00:00", "10:00:00", "10:00:00", "10:00:00", "10:00:00", "10:00:00"]
+const dev_times = [9.68, 9.46, 4.65, 5.13, 25.71, 600.00, 600.00, 600.00, 600.00, 600.00, 600.00, 600.00, 600.00, 600.00, 600.00]
 @export var high_score = 0
 @export var arcade_time = null

--- a/scripts/level_data.gd
+++ b/scripts/level_data.gd
@@ -5,6 +5,6 @@ class_name LevelData
 # Gets populated upon time trial level clear
 @export var level_times = {}
 # hard-coded developer best times for time trail levels. 
-const dev_times = [9.68, 9.47, 4.55, 5.06, 23.85, 19.25, 600.00, 17.49, 19.32, 600.00, 28.85, 12.80, 5.05, 17.92, 600.00]
+const dev_times = [9.68, 9.47, 4.55, 5.06, 23.85, 19.25, 15.22, 17.49, 19.32, 11.16, 28.85, 12.80, 5.05, 17.92, 38.38]
 @export var high_score = 0
 @export var arcade_time = null

--- a/scripts/level_data.gd
+++ b/scripts/level_data.gd
@@ -5,6 +5,6 @@ class_name LevelData
 # Gets populated upon time trial level clear
 @export var level_times = {}
 # hard-coded developer best times for time trail levels. 
-const dev_times: Array[int] = [9680, 9470, 4550, 5058, 23850, 19250, 15220, 17490, 19320, 11160, 28850, 12800, 5050, 17920, 38380]
+const dev_times: Array[int] = [9566, 9150, 4500, 5050, 21215, 16831, 14483, 14216, 18633, 10199, 28750, 11699, 4799, 16682, 31348]
 @export var high_score = 0
 @export var arcade_time = null

--- a/scripts/main.gd
+++ b/scripts/main.gd
@@ -9,7 +9,7 @@ func _ready():
 	%ArcadeButton.grab_focus()
 	%Score.text = str(GameManager.level_data.high_score)
 	if not GameManager.level_data.arcade_time == null:
-		%Time.text = GameManager.format_seconds(GameManager.level_data.arcade_time)
+		%Time.text = GameManager.format_milliseconds(GameManager.level_data.arcade_time)
 
 func _on_arcade_button_pressed() -> void:
 	GameManager.load_first_level()


### PR DESCRIPTION
- Added infrastructure to save best developer times
     - Adjusted size of "Time to Beat" label to make it the same as personal best time. 
- I still have times to set. Ben, if you want to try and set your own you can add them to level_data
- Ben: Feel free to add the golden border to this PR. 