### PR TITLE
(Target: `dev-times`): change all times to milliseconds

### DIFF
--- a/scripts/UI/hud.gd
+++ b/scripts/UI/hud.gd
@@ -21,7 +21,7 @@ func _process(_delta) -> void:
 	if GameManager.gameMode == GameManager.GameModes.ARCADE:
 		%Lives.text = "Lives: %d" % GameManager.lives
 		%Score.text = "Score: %d" % GameManager.score
-	%Timer.text = GameManager.format_seconds(GameManager.time)
+	%Timer.text = GameManager.format_milliseconds(GameManager.time)
 	
 func display_level_name():
 	if GameManager.gameMode == GameManager.GameModes.ARCADE:

--- a/scripts/UI/level_select.gd
+++ b/scripts/UI/level_select.gd
@@ -82,15 +82,18 @@ func _update_level_info_display(level_index):
 	if time == null or str(time) == "":
 		%LevelStats.text = "Level Not Complete"
 	else:
-		%LevelStats.text = GameManager.format_seconds(time)
+		%LevelStats.text = GameManager.format_milliseconds(time)
 	var dev_time = GameManager.level_data.dev_times[level_index]
-	%TimeToBeat.text = GameManager.format_seconds(dev_time)
+	%TimeToBeat.text = GameManager.format_milliseconds(dev_time)
 
 
 func _dev_time_beaten(level_index):
 	var level_file = level_files[level_index]
 	var level_path = "res://levels/%s" % level_file
-	var time = GameManager.level_data.level_times.get(level_path, 1000)
+	var recorded_time = GameManager.level_data.level_times.get(level_path, -1)
+	if recorded_time == -1:
+		return false
+
 	var dev_time = GameManager.level_data.dev_times[level_index]
 
-	return time < dev_time
+	return recorded_time < dev_time

--- a/scripts/level_data.gd
+++ b/scripts/level_data.gd
@@ -5,6 +5,6 @@ class_name LevelData
 # Gets populated upon time trial level clear
 @export var level_times = {}
 # hard-coded developer best times for time trail levels. 
-const dev_times = [9.68, 9.47, 4.55, 5.06, 23.85, 19.25, 600.00, 17.49, 19.32, 600.00, 600.00, 600.00, 600.00, 600.00, 600.00]
+const dev_times = [9680, 9470, 4550, 5060, 23850, 19250, 600000, 17490, 19320, 600000, 600000, 600000, 600000, 600000, 600000]
 @export var high_score = 0
 @export var arcade_time = null

--- a/scripts/main.gd
+++ b/scripts/main.gd
@@ -9,7 +9,7 @@ func _ready():
 	%ArcadeButton.grab_focus()
 	%Score.text = str(GameManager.level_data.high_score)
 	if not GameManager.level_data.arcade_time == null:
-		%Time.text = GameManager.format_seconds(GameManager.level_data.arcade_time)
+		%Time.text = GameManager.format_milliseconds(GameManager.level_data.arcade_time)
 
 func _on_arcade_button_pressed() -> void:
 	GameManager.load_first_level()


### PR DESCRIPTION
- Update all internal time representations to use milliseconds
- Storing times in seconds can result in floating point precision issues
  - this caused the bug where a time stored as 5.13 was rendered as 00:05:13.
- I would've just committed this to the `dev-times` branch, but it will break all existing saved times, as they are stored in seconds