### PR TITLE
Level name fade in is now centered across all levels

### DIFF
--- a/scenes/UI/hud.tscn
+++ b/scenes/UI/hud.tscn
@@ -59,16 +59,16 @@ vertical_alignment = 1
 
 [node name="LevelName" type="Label" parent="."]
 unique_name_in_owner = true
-visible = false
 custom_minimum_size = Vector2(300, 0)
 anchors_preset = 5
 anchor_left = 0.5
 anchor_right = 0.5
 offset_left = -500.0
 offset_top = 25.0
-offset_bottom = 67.0
+offset_bottom = 91.0
 grow_horizontal = 2
 scale = Vector2(2, 2)
 theme_override_styles/normal = ExtResource("2_0jeyp")
 label_settings = ExtResource("3_0jeyp")
 horizontal_alignment = 1
+vertical_alignment = 1

--- a/scenes/UI/hud.tscn
+++ b/scenes/UI/hud.tscn
@@ -60,11 +60,15 @@ vertical_alignment = 1
 [node name="LevelName" type="Label" parent="."]
 unique_name_in_owner = true
 visible = false
+custom_minimum_size = Vector2(300, 0)
 anchors_preset = 5
 anchor_left = 0.5
 anchor_right = 0.5
+offset_left = -500.0
 offset_top = 25.0
+offset_bottom = 67.0
 grow_horizontal = 2
 scale = Vector2(2, 2)
 theme_override_styles/normal = ExtResource("2_0jeyp")
 label_settings = ExtResource("3_0jeyp")
+horizontal_alignment = 1


### PR DESCRIPTION
- Fixed level fade in bug
- The level name label is bigger, but is now centered for all levels. (previously the length of the name would determine positioning)